### PR TITLE
move assets to linodeobjects

### DIFF
--- a/kuberneteslab/k8s/deployment.yaml
+++ b/kuberneteslab/k8s/deployment.yaml
@@ -75,7 +75,7 @@ spec:
         - name: ICECAST_ADMIN_USER
           value: "iceadmin@mars64.io"
         - name: ICECAST_ADMIN_PASS
-          value: "9UK9JqhqxuokF96LTpe9vhvnjR5vbGaK"
+          value: "plznuhhackmeh"
         - name: ICECAST_HOSTNAME
           value: "icecast.mars64.io"
         - name: ICECAST_LOCATION
@@ -83,9 +83,9 @@ spec:
         - name: ICECAST_PORT
           value: "8000"
         - name: ICECAST_RELAY_PASS
-          value: "9UK9JqhqxuokF96LTpe9vhvnjR5vbGaK"
+          value: "plznuhhackmeh"
         - name: ICECAST_STREAM_PASS
-          value: "9UK9JqhqxuokF96LTpe9vhvnjR5vbGaK"
+          value: "plznuhhackmeh"
         - name: ICECAST_VERSION
           value: "2.4.3-r4"
       - name: mpd
@@ -95,7 +95,7 @@ spec:
         - containerPort: 6600
         env:
         - name: ICECAST_STREAM_PASS
-          value: "9UK9JqhqxuokF96LTpe9vhvnjR5vbGaK"
+          value: "plznuhhackmeh"
         volumeMounts:
         - mountPath: /var/lib/mpd/music
           name: mpd-music

--- a/kuberneteslab/k8s/deployment.yaml
+++ b/kuberneteslab/k8s/deployment.yaml
@@ -73,9 +73,9 @@ spec:
             cpu: 10m
         env:
         - name: ICECAST_ADMIN_USER
-          value: "iceadmin@localhost"
+          value: "iceadmin@mars64.io"
         - name: ICECAST_ADMIN_PASS
-          value: "plznuhhackmeh"
+          value: "9UK9JqhqxuokF96LTpe9vhvnjR5vbGaK"
         - name: ICECAST_HOSTNAME
           value: "icecast.mars64.io"
         - name: ICECAST_LOCATION
@@ -83,9 +83,9 @@ spec:
         - name: ICECAST_PORT
           value: "8000"
         - name: ICECAST_RELAY_PASS
-          value: "plznuhhackmeh"
+          value: "9UK9JqhqxuokF96LTpe9vhvnjR5vbGaK"
         - name: ICECAST_STREAM_PASS
-          value: "plznuhhackmeh"
+          value: "9UK9JqhqxuokF96LTpe9vhvnjR5vbGaK"
         - name: ICECAST_VERSION
           value: "2.4.3-r4"
       - name: mpd
@@ -95,7 +95,7 @@ spec:
         - containerPort: 6600
         env:
         - name: ICECAST_STREAM_PASS
-          value: "plznuhhackmeh"
+          value: "9UK9JqhqxuokF96LTpe9vhvnjR5vbGaK"
         volumeMounts:
         - mountPath: /var/lib/mpd/music
           name: mpd-music

--- a/kuberneteslab/k8s/service.yaml
+++ b/kuberneteslab/k8s/service.yaml
@@ -15,9 +15,9 @@ spec:
     - name: icecast-stream
       port: 8000
       targetPort: 8000
-      ### type: LoadBalancer	
-      ### loadBalancerSourceRanges:
-      ### - your.ip.goes.here/32    
+      type: LoadBalancer	
+      loadBalancerSourceRanges:
+      - your.ip.goes.here/32    
 
 ---
 apiVersion: v1
@@ -33,6 +33,6 @@ spec:
     - name: ympd
       port: 80
       targetPort: 8080
-      ### type: LoadBalancer	
-      ### loadBalancerSourceRanges:
-      ### - your.ip.goes.here/32    
+      type: LoadBalancer	
+      loadBalancerSourceRanges:
+      - your.ip.goes.here/32    

--- a/kuberneteslab/k8s/service.yaml
+++ b/kuberneteslab/k8s/service.yaml
@@ -15,9 +15,9 @@ spec:
     - name: icecast-stream
       port: 8000
       targetPort: 8000
-      type: LoadBalancer	
-      loadBalancerSourceRanges:
-      - your.ip.goes.here/32    
+  type: LoadBalancer	
+  loadBalancerSourceRanges:
+  - your.ip.goes.here/32    
 
 ---
 apiVersion: v1
@@ -33,6 +33,6 @@ spec:
     - name: ympd
       port: 80
       targetPort: 8080
-      type: LoadBalancer	
-      loadBalancerSourceRanges:
-      - your.ip.goes.here/32    
+  type: LoadBalancer	
+  loadBalancerSourceRanges:
+  - your.ip.goes.here/32    

--- a/kuberneteslab/k8s/service.yaml
+++ b/kuberneteslab/k8s/service.yaml
@@ -15,9 +15,9 @@ spec:
     - name: icecast-stream
       port: 8000
       targetPort: 8000
-  type: LoadBalancer	
-  loadBalancerSourceRanges:
-  - your.ip.goes.here/32    
+      ### type: LoadBalancer	
+      ### loadBalancerSourceRanges:
+      ### - your.ip.goes.here/32    
 
 ---
 apiVersion: v1
@@ -33,6 +33,6 @@ spec:
     - name: ympd
       port: 80
       targetPort: 8080
-  type: LoadBalancer	
-  loadBalancerSourceRanges:
-  - your.ip.goes.here/32    
+      ### type: LoadBalancer	
+      ### loadBalancerSourceRanges:
+      ### - your.ip.goes.here/32    


### PR DESCRIPTION
* mpd container prep: the `chown` appears to have broken permissions in modern docker, reverting -- verified working locally