### PR TITLE
update for kaskada training day - 20200925

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 k8s specs for Icecast, mpd, ympd, sima - based on https://github.com/vitiMan/docker-music-stack
 
-This class was initially built for the [Software Freedom School](http://www.SoFree.us). Greetz out to SFS, ASG, IT/NTL and RP!
+This class was initially built for the [Software Freedom School](http://www.SoFree.us). Greetz out to SFS, ASG, IT/NTL, RP, Conga & Kaskada! This version of the class is specific for Kaskada! 
 
 - v1: minikube
 - v2: AWS and DigitalOcean
@@ -16,6 +16,5 @@ There is a slide deck included as a visual guide - but it not necessary for anyo
 Found a problem? Feel free to submit a PR ;)
 
 Happy kube'ing!
-
 
 -Mars

--- a/kuberneteslab/k8s/deployment.yaml
+++ b/kuberneteslab/k8s/deployment.yaml
@@ -77,7 +77,7 @@ spec:
         - name: ICECAST_ADMIN_PASS
           value: "plznuhhackmeh"
         - name: ICECAST_HOSTNAME
-          value: "icecast.mars64.io"
+          value: "icecast.YOURNAMESPACEHERE.beta.internal.kaskada.com"
         - name: ICECAST_LOCATION
           value: "DEEP BASS STATION 9"
         - name: ICECAST_PORT

--- a/kuberneteslab/k8s/service.yaml
+++ b/kuberneteslab/k8s/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: icecast
   annotations: 
-    external-dns.alpha.kubernetes.io/hostname: icecast.mars64.io.
+    external-dns.alpha.kubernetes.io/hostname: icecast.YOURNAMESPACEHERE.beta.internal.kaskada.com.
 spec:
   selector:
     app: k8s-music-stack
@@ -17,7 +17,7 @@ spec:
       targetPort: 8000
   type: LoadBalancer	
   loadBalancerSourceRanges:
-  - your.ip.goes.here/32    
+  - YOUR.PUBLIC.IP.HERE/32
 
 ---
 apiVersion: v1
@@ -25,7 +25,7 @@ kind: Service
 metadata:
   name: ympd
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: ympd.mars64.io.
+    external-dns.alpha.kubernetes.io/hostname: ympd.YOURNAMESPACEHERE.beta.internal.kaskada.com.
 spec:
   selector:
     app: k8s-music-stack
@@ -35,4 +35,4 @@ spec:
       targetPort: 8080
   type: LoadBalancer	
   loadBalancerSourceRanges:
-  - your.ip.goes.here/32    
+  - YOUR.PUBLIC.IP.HERE/32    


### PR DESCRIPTION
* updates k8s labs 1 and 2
* uses Kaskada's internal zone: `beta.internal.kaskada.com`
* will redact internal zone after training